### PR TITLE
builtin authentication-enabled reverse proxy for dkron (instead of re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Manage and run jobs in Dkron from your django project
 
+## Authentication
+
+
 ## ToDo
 
 * Make README useful!

--- a/dkron/apps.py
+++ b/dkron/apps.py
@@ -1,3 +1,4 @@
+from django.shortcuts import reverse
 from django.apps import AppConfig
 from django.conf import settings
 
@@ -5,7 +6,7 @@ APP_SETTINGS = dict(
     URL=None,
     PATH=None,
     BIN_DIR=None,
-    VERSION='3.1.8',
+    VERSION='3.1.10',
     DOWNLOAD_URL_TEMPLATE='https://github.com/distribworks/dkron/releases/download/v{version}/dkron_{version}_{system}_amd64.tar.gz',
     WEB_PORT=None,
     SERVER=False,
@@ -27,5 +28,9 @@ class DkronConfig(AppConfig):
     def ready(self):
         for k, v in APP_SETTINGS.items():
             _k = 'DKRON_%s' % k
-            if not hasattr(settings, _k):
-                setattr(settings, _k, v)
+            if hasattr(settings, _k):
+                continue
+            if (k, v) == ('PATH', None):
+                # special one to default to reverse url
+                v = reverse('dkron:proxy')
+            setattr(settings, _k, v)

--- a/dkron/urls.py
+++ b/dkron/urls.py
@@ -1,7 +1,11 @@
-from django.urls import path
+from django.urls import path, re_path
 
 from . import views
 
 app_name = 'dkron'
 
-urlpatterns = [path('auth/', views.auth, name='auth')]
+urlpatterns = [
+    path('auth/', views.auth, name='auth'),
+    path('_/', views.proxy, name='proxy'),
+    re_path(r'_/(?P<path>.*)$', views.proxy),
+]

--- a/dkron/views.py
+++ b/dkron/views.py
@@ -1,7 +1,11 @@
+import requests
+
 from django import http
+from django.shortcuts import reverse
 from django.conf import settings
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
+from django.contrib.auth.decorators import permission_required
 
 from notifications.utils import notify
 from dkron import models, utils
@@ -50,3 +54,79 @@ def webhook(request):
             )}|failed>''',
         )
     return http.HttpResponse()
+
+
+@permission_required('dkron.can_use_dashboard')
+@csrf_exempt
+def proxy(request, path=None):
+    """
+    reverse proxy implementation based on https://github.com/mjumbewu/django-proxy/blob/master/proxy/views.py
+    this is a simplified implementation that "just works" for Dkron but is definitely missing cases for reverse proxying other backends
+    re-use in other projects at your own discretion :)
+
+    refer to `dkron authentication` section in docs #FIXME
+    """
+    headers = {
+        k: v
+        for k, v in request.headers.items()
+        # content-length is not used by requests and might get duplicated (due to casing), just remove it
+        # also, dkron does not use cookies, simply drop the whole header to avoid sending django app session over
+        if k.lower() not in ('content-length', 'cookie')
+    }
+    url = settings.DKRON_URL + (path or '')
+
+    response = requests.request(
+        request.method,
+        url,
+        allow_redirects=False,
+        headers=headers,
+        params=request.GET.copy(),
+        data=request.body,
+    )
+
+    proxy_response = http.HttpResponse(response.content, status=response.status_code)
+
+    excluded_headers = set(
+        [
+            # Hop-by-hop headers
+            # ------------------
+            # Certain response headers should NOT be just tunneled through.  These
+            # are they.  For more info, see:
+            # http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1
+            'connection',
+            'keep-alive',
+            'proxy-authenticate',
+            'proxy-authorization',
+            'te',
+            'trailers',
+            'transfer-encoding',
+            'upgrade',
+            # Although content-encoding is not listed among the hop-by-hop headers,
+            # it can cause trouble as well.  Just let the server set the value as
+            # it should be.
+            'content-encoding',
+            # Since the remote server may or may not have sent the content in the
+            # same encoding as Django will, let Django worry about what the length
+            # should be.
+            'content-length',
+        ]
+    )
+    for key, value in response.headers.items():
+        if key.lower() in excluded_headers:
+            continue
+        elif key.lower() == 'location':
+            proxy_response[key] = _fix_location_header(path, value)
+        else:
+            proxy_response[key] = value
+
+    return proxy_response
+
+
+def _fix_location_header(path, location):
+    base = reverse('dkron:proxy')
+    if location.startswith(settings.DKRON_URL):
+        return base + location[len(settings.DKRON_URL) :]
+    elif location.startswith('/'):
+        return base + location[1:]
+    else:
+        return base + (path or '') + '/' + location

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -131,4 +131,4 @@ DKRON_SERVER = True
 # as defined in nginx proxypass location + dashboard to avoid redirect such as:
 # DKRON_PATH = '/dkron/ui/ui/'
 # for local dev, adding full URL (directly into dkron) to avoid setting up nginx
-DKRON_PATH = 'http://localhost:8888/ui/'
+# DKRON_PATH = 'http://localhost:8888/ui/'

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -44,7 +44,7 @@ class Test(TestCase):
         self.assertEqual(settings.DKRON_URL, None)
 
     def test_auth(self):
-        r = self.client.get('/dkron/auth/')
+        r = self.client.get(reverse('dkron:auth'))
         self.assertEqual(r.status_code, 401)
 
         self._login()


### PR DESCRIPTION
builtin authentication-enabled reverse proxy for dkron (instead of requiring nginx)

note: default dkron version updated to 3.1.10 - it's not a breaking change and anyone using "default" version can set `DKRON_VERSION = '3.1.8'` in their settings