### PR TITLE
job "namespacing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following app settings are available for customization (from [dkron/apps.py]
 | DKRON_API_AUTH |  | HTTP Basic auth header value, if dkron instance is protected with it (really recommended, if instance is exposed) |
 | DKRON_TOKEN |  | Token used by `run_dkron` for webhook calls into this app |
 | DKRON_WEBHOOK_URL |  | URL called by dkron webhooks to post job status to this app - passed as `--webhook-url` to dkron, so you need to map `dkron.views.webhook` in your project urls.py and this should be full URL to that route and reachable by dkron|
+| DKRON_NAMESPACE | | string to be prefixed to each job created by this app in dkron so the same dkron cluster can be used by different apps/instances without conflicting job names (assuming unique namespaces ^^) |
 
 Besides starting the django app (with `./manage.py runserver`, `gunicorn` or similar) also start dkron agent with `./manage.py run_dkron`:
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The following app settings are available for customization (from [dkron/apps.py]
 | DKRON_VERSION | `3.1.10` | dkron version to (download and) use |
 | DKRON_DOWNLOAD_URL_TEMPLATE | `https://github.com/distribworks/dkron/releases/download/v{version}/dkron_{version}_{system}_amd64.tar.gz` | can be changed in case a dkron fork is meant to be used |
 | DKRON_SERVER | `False` | always `run_dkron` in server mode |
-| DKRON_TAGS | `[]` | tags for the agent/server created by `run_dkron` |
-| DKRON_JOB_LABEL | | label for the jobs managed by this app - make sure that any labels here are part of TAGS otherwise agent will not pick up the job |
+| DKRON_TAGS | `[]` | tags for the agent/server created by `run_dkron` - `label=` tag is not required as it is added by `DKRON_JOB_LABEL` |
+| DKRON_JOB_LABEL | | label for the jobs managed by this app, used to make this app agent run only jobs created by this app |
 | DKRON_JOIN | `[]` | --join when using `run_dkron` |
 | DKRON_WORKDIR |  | workdir of `run_dkron` |
 | DKRON_ENCRYPT |  | gossip encrypt key for `run_dkron` |

--- a/dkron/apps.py
+++ b/dkron/apps.py
@@ -15,9 +15,9 @@ APP_SETTINGS = dict(
     DOWNLOAD_URL_TEMPLATE='https://github.com/distribworks/dkron/releases/download/v{version}/dkron_{version}_{system}_amd64.tar.gz',
     # always `run_dkron` in server mode
     SERVER=False,
-    # tags for the agent/server created by `run_dkron`
+    # tags for the agent/server created by `run_dkron` - `label=` tag is not required as it is added by `DKRON_JOB_LABEL`
     TAGS=[],
-    # label for the jobs managed by this app - make sure that any labels here are part of TAGS otherwise agent will not pick up the job
+    # label for the jobs managed by this app, used to make this app agent run only jobs created by this app`
     JOB_LABEL=None,
     # --join when using `run_dkron`
     JOIN=[],

--- a/dkron/apps.py
+++ b/dkron/apps.py
@@ -31,6 +31,8 @@ APP_SETTINGS = dict(
     TOKEN=None,
     # URL called by dkron webhooks to post job status to this app - passed as `--webhook-url` to dkron, so you need to map `dkron.views.webhook` in your project urls.py and this should be full URL to that route and reachable by dkron
     WEBHOOK_URL=None,
+    # string to be prefixed to each job created by this app in dkron so the same dkron cluster can be used by different apps/instances without conflicting job names (assuming unique namespaces ^^)
+    NAMESPACE=None,
 )
 
 

--- a/dkron/management/commands/run_dkron.py
+++ b/dkron/management/commands/run_dkron.py
@@ -72,6 +72,9 @@ class Command(LogBaseCommand):
             args.extend(['--encrypt', options['encrypt'] or settings.DKRON_ENCRYPT])
         for tag in settings.DKRON_TAGS or []:
             args.extend(['--tag', tag])
+        # make sure the LABEL tag is included
+        if settings.DKRON_JOB_LABEL:
+            args.extend(['--tag', f'label={settings.DKRON_JOB_LABEL}'])
         for j in options['join'] or settings.DKRON_JOIN or []:
             args.extend(['--join', j])
         if settings.DKRON_WORKDIR:

--- a/dkron/models.py
+++ b/dkron/models.py
@@ -22,5 +22,17 @@ class Job(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def namespaced_name(self):
+        return utils.add_namespace(self.name)
+
+    @property
+    def parent_name(self):
+        return self.schedule[8:] if self.schedule.startswith('@parent ') else ''
+
     class Meta:
         permissions = (("can_use_dashboard", "Can use the dashboard"),)
+
+
+# circular dependency
+from . import utils

--- a/dkron/utils.py
+++ b/dkron/utils.py
@@ -117,7 +117,8 @@ def resync_jobs() -> Iterator[tuple[str, Literal["u", "d"], Optional[str]]]:
     previous_jobs = {y['name']: y for y in r.json()}
     if settings.DKRON_JOB_LABEL:
         previous_jobs = {
-            y['name']: y for y in previous_jobs.values()
+            y['name']: y
+            for y in previous_jobs.values()
             if settings.DKRON_JOB_LABEL == y.get('tags', {}).get('label', '')
         }
 

--- a/dkron/utils.py
+++ b/dkron/utils.py
@@ -115,6 +115,11 @@ def resync_jobs() -> Iterator[tuple[str, Literal["u", "d"], Optional[str]]]:
         raise DkronException(r.status_code, r.text)
 
     previous_jobs = {y['name']: y for y in r.json()}
+    if settings.DKRON_JOB_LABEL:
+        previous_jobs = {
+            y['name']: y for y in previous_jobs.values()
+            if settings.DKRON_JOB_LABEL == y.get('tags', {}).get('label', '')
+        }
 
     # just post all jobs even if they already exist
     # cheaper than checking all the differences (probably)

--- a/dkron/views.py
+++ b/dkron/views.py
@@ -38,8 +38,11 @@ def webhook(request):
     if lines[0] != settings.DKRON_TOKEN:
         return http.HttpResponseForbidden()
 
-    o = models.Job.objects.filter(name=lines[1]).first()
+    job_name = utils.trim_namespace(lines[1])
+    if not job_name:
+        return http.HttpResponseNotFound()
 
+    o = models.Job.objects.filter(name=job_name).first()
     if o is None:
         return http.HttpResponseNotFound()
 

--- a/dkron/views.py
+++ b/dkron/views.py
@@ -73,7 +73,7 @@ def proxy(request, path=None):
         # also, dkron does not use cookies, simply drop the whole header to avoid sending django app session over
         if k.lower() not in ('content-length', 'cookie')
     }
-    url = settings.DKRON_URL + (path or '')
+    url = utils.dkron_url() + (path or '')
 
     if settings.DKRON_API_AUTH:
         headers['Authorization'] = f'Basic {settings.DKRON_API_AUTH}'
@@ -127,8 +127,8 @@ def proxy(request, path=None):
 
 def _fix_location_header(path, location):
     base = reverse('dkron:proxy')
-    if location.startswith(settings.DKRON_URL):
-        return base + location[len(settings.DKRON_URL) :]
+    if location.startswith(utils.dkron_url()):
+        return base + location[len(utils.dkron_url()) :]
     elif location.startswith('/'):
         return base + location[1:]
     else:

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -123,7 +123,6 @@ STATIC_URL = '/static/'
 
 DKRON_TOKEN = 'test'
 DKRON_URL = 'http://localhost:8888/'
-DKRON_TAGS = ['label=testapp']
 DKRON_JOB_LABEL = 'testapp'
 DKRON_SERVER = True
 

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -22,8 +22,8 @@ from dkron.apps import DkronConfig
 @override_settings(DKRON_PATH='/dkron/proxy/ui/', DKRON_URL='http://dkron')
 class Test(TestCase):
     def setUp(self):
-        # always reset _lazy_url cache as tests might need to use different settings
-        utils._lazy_url._cache = None
+        # always reset api_url cache as tests might need to use different settings
+        utils.api_url.cache_clear()
         self.user = get_user_model().objects.create_user('tester', 'tester@ppb.it', 'tester')
         self.site = AdminSite()
 
@@ -88,14 +88,14 @@ class Test(TestCase):
         j = models.Job.objects.create(name='job1')
         self.assertEqual(str(j), 'job1')
 
-    def test_lazy_url(self):
+    def test_api_url(self):
         with self.settings(DKRON_URL='http://dkron'):
-            utils._lazy_url._cache = None
-            self.assertEqual(utils._lazy_url(), 'http://dkron/v1/')
+            utils.api_url.cache_clear()
+            self.assertEqual(utils.api_url(), 'http://dkron/v1/')
 
         with self.settings(DKRON_URL='http://dkron/'):
-            utils._lazy_url._cache = None
-            self.assertEqual(utils._lazy_url(), 'http://dkron/v1/')
+            utils.api_url.cache_clear()
+            self.assertEqual(utils.api_url(), 'http://dkron/v1/')
 
     def test_sync_job(self):
         j = models.Job.objects.create(name='job1')

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -194,11 +194,7 @@ class Test(TestCase):
         mp1.return_value = mock.MagicMock(status_code=200, json=lambda: jobs)
         it = utils.resync_jobs()
 
-        with mock.patch(
-            'dkron.utils.sync_job'
-        ) as mp2, mock.patch(
-            'dkron.utils.delete_job'
-        ) as mp3:
+        with mock.patch('dkron.utils.sync_job') as mp2, mock.patch('dkron.utils.delete_job') as mp3:
             el = next(it)
             mp1.assert_called_once_with('http://dkron/v1/jobs', params={'metadata[cron]': 'auto'})
             self.assertEqual(('job1', 'u', None), el)
@@ -513,7 +509,7 @@ class Test(TestCase):
         self.user.save()
         r = self.client.get(reverse('dkron:proxy'))
         self.assertEqual(302, r.status_code)
-        
+
         mp1.return_value = mock.MagicMock(content='', status_code=202)
         self._login()
         r = self.client.get(reverse('dkron:proxy'))
@@ -528,19 +524,21 @@ class Test(TestCase):
         self.user.user_permissions.add(self._job_perm('can_use_dashboard'))
         r = self.client.get(reverse('dkron:proxy'))
         self.assertEqual(202, r.status_code)
-    
+
     @mock.patch('requests.request')
     def test_proxy_view(self, mp1):
         self.user.is_superuser = True
         self.user.save()
         self._login()
-        
+
         mp1.return_value = mock.MagicMock(content='raw content', status_code=202)
         r = self.client.get(reverse('dkron:proxy'))
         self.assertEqual(202, r.status_code)
         self.assertEqual(b'raw content', r.content)
 
-        mp1.return_value = mock.MagicMock(content='raw content', status_code=302, headers={'Location': 'whatever', 'X-Custom': 'untouched'})
+        mp1.return_value = mock.MagicMock(
+            content='raw content', status_code=302, headers={'Location': 'whatever', 'X-Custom': 'untouched'}
+        )
         r = self.client.get(reverse('dkron:proxy'))
         self.assertEqual(302, r.status_code)
         self.assertEqual(b'raw content', r.content)
@@ -549,7 +547,9 @@ class Test(TestCase):
         # non-specific header remains untouched
         self.assertEqual('untouched', r.headers['x-custom'])
 
-        mp1.return_value = mock.MagicMock(content='', status_code=302, headers={'Location': '/whatever', 'Content-Encoding': 'invalid'})
+        mp1.return_value = mock.MagicMock(
+            content='', status_code=302, headers={'Location': '/whatever', 'Content-Encoding': 'invalid'}
+        )
         r = self.client.get(reverse('dkron:proxy'))
         self.assertEqual(302, r.status_code)
         # leading / is trimmed


### PR DESCRIPTION
Option to prefix every job name with a fixed string (in dkron), allowing different django projects or instances (using this app) to share the same dkron cluster without overriding jobs