### PR TITLE
allow customizing node name

### DIFF
--- a/dkron/apps.py
+++ b/dkron/apps.py
@@ -33,6 +33,8 @@ APP_SETTINGS = dict(
     WEBHOOK_URL=None,
     # string to be prefixed to each job created by this app in dkron so the same dkron cluster can be used by different apps/instances without conflicting job names (assuming unique namespaces ^^)
     NAMESPACE=None,
+    # node name to be passed to dkron as `--node-name` - defaults to machine hostname
+    NODE_NAME=None,
 )
 
 

--- a/dkron/management/commands/run_dkron.py
+++ b/dkron/management/commands/run_dkron.py
@@ -23,6 +23,12 @@ class Command(LogBaseCommand):
         parser.add_argument(
             '-e', '--encrypt', type=str, help='Key for encrypting network traffic. Must be a base64-encoded 16-byte key'
         )
+        parser.add_argument(
+            '--node-name',
+            type=str,
+            default=settings.DKRON_NODE_NAME,
+            help='Key for encrypting network traffic. Must be a base64-encoded 16-byte key',
+        )
 
     def download_dkron(self):
         """
@@ -96,6 +102,8 @@ class Command(LogBaseCommand):
             )
         if options['encrypt'] or settings.DKRON_ENCRYPT:
             args.extend(['--encrypt', options['encrypt'] or settings.DKRON_ENCRYPT])
+        if options['node_name']:
+            args.extend(['--node-name', options['node_name']])
         for tag in settings.DKRON_TAGS or []:
             args.extend(['--tag', tag])
         # make sure the LABEL tag is included


### PR DESCRIPTION
raft is hard.

if current node name does not match the existing log, there's no consensus (even in a single node cluster) and no leader.

with containers, relying on hostname for node name might (will!) not work.