### PR TITLE
Drops Django upper bound limit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 # requires 3.9 due to django-notification-sender...
 python_requires = >=3.9
 install_requires =
-    Django >= 3.0, <4
+    Django >= 3.0
     django-logbasecommand < 1
     django-notification-sender < 1
     requests > 2, < 3

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist =
     flake8
-    py{39}-dj{22,30,32}
+    py{39}-dj{22,30,32,41}
 
 [testenv]
 deps =
     dj22: Django==2.2.*
     dj30: Django==3.0.*
     dj32: Django==3.2.*
+    dj41: Django==4.1.*
     coverage
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
This change facilitates integrating this project into others by removing the Django < 4 restriction. 3.2.16 is LTS though, at the time of writing. Looking particularly at https://github.com/surface-security/surface/pull/38

If we need the pin for a particular reason, please let's document that need in the project somewhere.