### PR TITLE
`run_async` should run async

### DIFF
--- a/dkron/utils.py
+++ b/dkron/utils.py
@@ -267,10 +267,16 @@ def __run_async_dkron(command, *args, **kwargs) -> tuple[str, str]:
             'disabled': False,
             'executor_config': {'command': final_command},
         },
-        params={'runoncreate': 'true'},
+        # FIXME: workaround for https://github.com/surface-security/django-dkron/issues/18
+        # if dkron fixes it, restore this (either based on dkron version or ignore the bug for old version...)
+        # params={'runoncreate': 'true'},
     )
 
     if r.status_code != 201:
+        raise DkronException(r.status_code, r.text)
+
+    r = _post(f'jobs/{add_namespace(name)}')
+    if r.status_code != 200:
         raise DkronException(r.status_code, r.text)
 
     return name, job_executions(name)

--- a/testapp/requirements.txt
+++ b/testapp/requirements.txt
@@ -2,4 +2,4 @@
 pytest==6.2.5
 pytest-cov==2.12.1
 pytest-django==4.4.0
-black==22.1.0
+black>22.1.0

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -431,7 +431,8 @@ class Test(TestCase):
         # Because of the way mock attributes are stored you can’t directly attach a PropertyMock to a mock object
         # https://docs.python.org/3/library/unittest.mock.html#raising-exceptions-on-attribute-access
         type(mpp).status_code = mock.PropertyMock(side_effect=[201, 200])
-        x = utils.run_async('somecommand', 'arg1', kwarg='value', enable=True)
+        with mock.patch('django.utils.timezone.now', return_value=timezone.make_aware(timezone.datetime(2023, 2, 7))):
+            x = utils.run_async('somecommand', 'arg1', kwarg='value', enable=True)
         mp.assert_has_calls(
             (
                 mock.call(
@@ -439,13 +440,12 @@ class Test(TestCase):
                     json={
                         'name': f'{job_prefix}tmp_somecommand_1',
                         'tags': {'label': 'testapp:1'},
-                        'schedule': '@manually',
+                        'schedule': '@at 2023-02-07T00:00:05+00:00',
                         'executor_config': {'command': 'python ./manage.py somecommand arg1 --kwarg value --enable'},
                         'metadata': {'temp': 'true'},
                         'disabled': False,
                         'executor': 'shell',
                     },
-                    params={'runoncreate': 'true'},
                 ),
             )
         )


### PR DESCRIPTION
Workaround for https://github.com/surface-security/django-dkron/issues/18

This should be revisited once there are any updated there

Before change
```
➜  time ./manage.py shell -c 'from dkron.utils import run_async; run_async("shell", c="\"import time;time.sleep(10)\"")'
./manage.py shell -c   0.42s user 0.07s system 4% cpu 11.120 total

➜  time ./manage.py shell -c 'from dkron.utils import run_async; run_async("shell", c="\"import time;time.sleep(5)\"")'
./manage.py shell -c   0.43s user 0.07s system 8% cpu 6.119 total
```

Test changes in https://github.com/surface-security/django-dkron/pull/19/commits/d798b4d9eecdaa502d855af9042f767f0cf66e3d reflect the same timings, so it's not a solution.

Left with the option to use `@at +5seconds`, I'm unable to think of any other.

After changes

```
➜  time ./manage.py shell -c 'from dkron.utils import run_async; run_async("shell", c="\"import time;time.sleep(10)\"")'
./manage.py shell -c   0.43s user 0.07s system 90% cpu 0.555 total
➜  time ./manage.py shell -c 'from dkron.utils import run_async; run_async("shell", c="\"import time;time.sleep(3)\"")'
./manage.py shell -c   0.44s user 0.07s system 92% cpu 0.550 total
```

And the job is indeed triggered in dkron.