### PR TITLE
setup: move <4 requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,9 @@ zip_safe = False
 include_package_data = True
 packages = find:
 # requires 3.9 due to django-notification-sender...
-python_requires = >=3.9, < 4
+python_requires = >=3.9
 install_requires =
-    Django >= 3.0
+    Django >= 3.0, < 4
     django-logbasecommand < 1
     django-notification-sender < 1
     requests > 2, < 3


### PR DESCRIPTION
Mistakenly the `< 4` was put forth in Python version when it should have been Django's.
Plus, while on it, solved FIXME item and moved the dependency to optional and adding in the docs for users to install the optional dependency if they want to use it.