### PR TITLE
development releases under new package name

### DIFF
--- a/.github/workflows/publish_develop.yml
+++ b/.github/workflows/publish_develop.yml
@@ -1,11 +1,12 @@
 # This workflows will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: publish
+name: publish develop
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - develop
 
 jobs:
   publish:
@@ -20,6 +21,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+    - name: Update package name, version and README
+      run: |
+        sed -i 's/^name = django-dkron$/name = django-dkron-dev/' setup.cfg
+        sed -i "s/^__version__ = .*/__version__ = '0.${{ github.run_number }}'/" dkron/__init__.py
+        echo dev releases from https://github.com/surface-security/django-dkron > README.md
+    - name: Confirm package name changed
+      run: test -n "$(git status --porcelain setup.cfg)"
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -11,7 +11,7 @@ on:
     - testpypi/*
 
 jobs:
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Instead of using release candidate / postfixes in versions, let's use a different package name.

This avoids polluting main package (as there is no purging in pypi) and also resolves the issues with making sense out of versioning. This way we can version completely separately (such as just bumping major version on every commit)

Those projects using this dev package should first install the stable one, otherwise other packages that depend on django-dkron might install the stable *on top* of the dev

PoC:
https://pypi.org/project/django-dkron-dev/

* `-dev` suffix picked for no specific reason - maybe we could use a completely different name to "hide" it away from searches, open to suggestions
* added run_number as minor version instead of major, so we can bump major when we need to force all to be major: github does not allows to choose starting run_number so we cannot reset it nor set it to an initial value - if we change workflow name at some point, run number will go back to 1 and those versions would already exist
* simple hacky logic for replacements, we can improve this in a reusable action after adding to a few packages (to make sure we cover most use-cases)