### PR TITLE
Add validation to Job schedule to prevent scheduling jobs every second

### DIFF
--- a/dkron/__init__.py
+++ b/dkron/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 
 # set default_app_config when using django earlier than 3.2
 try:

--- a/dkron/__init__.py
+++ b/dkron/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.3'
+__version__ = '1.2.0'
 
 # set default_app_config when using django earlier than 3.2
 try:

--- a/dkron/admin.py
+++ b/dkron/admin.py
@@ -8,6 +8,7 @@ from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html
 from dkron import models, utils
+from dkron.forms import JobForm
 
 
 class JobAdminForm(forms.ModelForm):
@@ -53,6 +54,7 @@ class JobAdmin(admin.ModelAdmin):
     search_fields = ('name', 'schedule', 'command', 'description')
     list_filter = ('name', 'schedule', 'enabled', 'last_run_success', 'notify_on_error')
     actions = ['disable_jobs', 'enable_jobs']
+    form = JobForm
 
     def has_dashboard_permission(self, request):
         return request.user.has_perm('dkron.can_use_dashboard')

--- a/dkron/forms.py
+++ b/dkron/forms.py
@@ -5,5 +5,7 @@ class JobForm(forms.ModelForm):
     def clean_schedule(self):
         data = self.cleaned_data["schedule"]
         if data.startswith("*"):
-            raise forms.ValidationError("Job schedule cannot start with * as this will schedule a job to start every second and can have unintended consequences.")
+            raise forms.ValidationError(
+                "Job schedule cannot start with * as this will schedule a job to start every second and can have unintended consequences."
+            )
         return data

--- a/dkron/forms.py
+++ b/dkron/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from dkron.models import Job
 
 
 class JobForm(forms.ModelForm):
@@ -9,3 +10,7 @@ class JobForm(forms.ModelForm):
                 "Job schedule cannot start with * as this will schedule a job to start every second and can have unintended consequences."
             )
         return data
+
+    class Meta:
+        model = Job
+        fields = "__all__"

--- a/dkron/forms.py
+++ b/dkron/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+
+class JobForm(forms.ModelForm):
+    def clean_schedule(self):
+        data = self.cleaned_data["schedule"]
+        if data.startswith("*"):
+            raise forms.ValidationError("Job schedule cannot start with * as this will schedule a job to start every second and can have unintended consequences.")
+        return data

--- a/testapp/testapp/urls.py
+++ b/testapp/testapp/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path, include
 

--- a/testapp/tests/test_generic.py
+++ b/testapp/tests/test_generic.py
@@ -182,7 +182,7 @@ class Test(TestCase):
             self.assertEqual(exc.exception.message, 'Whatever')
 
     def test_job_form(self, job_prefix=''):
-        form_data = {'name': 'job1', 'schedule': '* 0 1 * * *', 'command': 'echo test'}
+        form_data = {'name': 'job1', 'schedule': '* 0 1 * * *', 'command': 'echo test', "retries": 0}
         form = JobForm(data=form_data)
         self.assertEqual(form.is_valid(), False)
         self.assertEquals(

--- a/testapp/tests/test_generic.py
+++ b/testapp/tests/test_generic.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from notifications import models as notify_models
 from dkron import admin, models, utils
 from dkron.apps import DkronConfig
+from dkron.forms import JobForm
 
 PROXY_VIEW = 'dkron:proxy'
 JOBS_URL = 'http://dkron/v1/jobs'
@@ -179,6 +180,14 @@ class Test(TestCase):
                 utils.sync_job('job1')
             self.assertEqual(exc.exception.code, 500)
             self.assertEqual(exc.exception.message, 'Whatever')
+
+    def test_job_form(self, job_prefix=''):
+        form_data = {
+            'name':'job1', 'schedule': '* 0 1 * * *', 'command': 'echo test'
+        }
+        form = JobForm(data=form_data)
+        self.assertEqual(form.is_valid(), False)
+        self.assertEquals(form.errors['schedule'], ["Job schedule cannot start with * as this will schedule a job to start every second and can have unintended consequences."])
 
     def test_delete_job(self, job_prefix=''):
         j = models.Job.objects.create(name='job1')

--- a/testapp/tests/test_generic.py
+++ b/testapp/tests/test_generic.py
@@ -182,12 +182,18 @@ class Test(TestCase):
             self.assertEqual(exc.exception.message, 'Whatever')
 
     def test_job_form(self, job_prefix=''):
-        form_data = {
-            'name':'job1', 'schedule': '* 0 1 * * *', 'command': 'echo test'
-        }
+        form_data = {'name': 'job1', 'schedule': '* 0 1 * * *', 'command': 'echo test'}
         form = JobForm(data=form_data)
         self.assertEqual(form.is_valid(), False)
-        self.assertEquals(form.errors['schedule'], ["Job schedule cannot start with * as this will schedule a job to start every second and can have unintended consequences."])
+        self.assertEquals(
+            form.errors['schedule'],
+            [
+                "Job schedule cannot start with * as this will schedule a job to start every second and can have unintended consequences."
+            ],
+        )
+        form_data = {'name': 'job1', 'schedule': '0 0 1 * * *', 'command': 'echo test', "retries": 0}
+        form = JobForm(data=form_data)
+        self.assertEqual(form.is_valid(), True)
 
     def test_delete_job(self, job_prefix=''):
         j = models.Job.objects.create(name='job1')


### PR DESCRIPTION
Added validation to `schedule` to prevent jobs running every second as this breaks dkron and the nodes need to be restarted to clean up the hanging jobs.

![image](https://github.com/user-attachments/assets/98de0733-68e1-459f-974b-31e0f4fa6493)
